### PR TITLE
fix: set node env correctly for multiple paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 node_modules
+.vscode

--- a/lib/rules.js
+++ b/lib/rules.js
@@ -94,7 +94,7 @@ function testModulePath(value, fileDir, aliases, extensions, context) {
 
     try {
         resolve.sync(value, {
-            paths: [process.env.NODE_PATH],
+            paths: process.env.NODE_PATH ? process.env.NODE_PATH.split(path.delimiter) : [],
             basedir: fileDir,
             extensions
         });


### PR DESCRIPTION
set node env correctly for multiple paths