### PR TITLE
put npm versioning logic in a separate file

### DIFF
--- a/bin/ut-release.js
+++ b/bin/ut-release.js
@@ -1,113 +1,16 @@
 #!/usr/bin/env node
-/* eslint no-process-env:0, no-console:0, no-process-exit:0 */
-
-var path = require('path');
-var obfuscator = require('../lib/obfuscator');
-var conventionalRecommendedBump = require('conventional-recommended-bump');
-var semver = require('semver');
-var packageJson = require(path.join(process.cwd(), 'package.json'));
-var pkgVersions = require('pkg-versions');
-var exec = require('../lib/exec');
-var buildableBranches = {
-    hotfix: 'patch',
-    major: 'premajor',
-    minor: 'preminor',
-    patch: 'prepatch'
-};
-conventionalRecommendedBump({
-    preset: 'angular'
-}, function(err, result) {
-    if (err) {
-        throw err;
-    } else {
-        var releaseType = result.releaseType;
-        var currentVersion = packageJson.version;
-        var tokens = [];
-        var setTag = false;
-        // if (process.env.gitlabSourceBranch) {
-        // tokens = process.env.gitlabSourceBranch.split('/');
-        // } else
-        if (process.env.CIRCLE_BRANCH) {
-            tokens = process.env.CIRCLE_BRANCH.split('/');
-        } else if (process.env.GIT_BRANCH) {
-            tokens = process.env.GIT_BRANCH.split('/').slice(1); // remove origin
-        } else {
-            throw new Error('Branch name could not be detected!');
-        }
-        var versionToRelease;
-        if (tokens.length === 2 && buildableBranches[tokens[0]] && tokens[1]) {
-            releaseType = buildableBranches[tokens[0]];
-            if (releaseType.startsWith('pre')) {
-                var prereleaseTokens = semver.prerelease(currentVersion);
-                if (prereleaseTokens) {
-                    if (prereleaseTokens[0] !== tokens[1]) {
-                        throw new Error(`Release version mismatch: Version ${prereleaseTokens[0]} can't be released from version ${tokens[1]}`);
-                    }
-                    releaseType = 'prerelease';
-                } else {
-                    if (!semver.prerelease(currentVersion + '-' + tokens[1])) {
-                        throw new Error(`incorrect branch name: ${tokens.join('/')}! ${tokens[1]} MUST comprise only [0-9A-Za-z-]`);
-                    }
-                    versionToRelease = semver.inc(currentVersion, releaseType, tokens[1]);
-                }
-            }
-        } else if (tokens.length > 1 || (tokens.length === 1 && tokens[0] !== 'master')) {
-            throw new Error(`incorrect branch name: ${tokens.join('/')}! Allowed branch names: master, hotfix/*, major/*, minor/*, patch/*`);
-        }
-        if (!versionToRelease) {
-            if (tokens[0] === 'master') {
-                setTag = true;
-            }
-            versionToRelease = semver.inc(currentVersion, releaseType);
-        }
-        return pkgVersions(packageJson.name)
-        .catch(function() {
-            // return empty array in case a list of current versions could not be obtained.
-            // This is needed when publishing for the first time.
-            return [];
-        })
-        .then(function(versions) {
-            var conflictingSemverDiff = releaseType;
-            var prereleaseName = '';
-            if (releaseType.startsWith('pre')) {
-                conflictingSemverDiff = 'prerelease';
-                prereleaseName = semver.prerelease(versionToRelease)[0];
-            }
-            var conflictingVersions = Array.from(versions).filter((version) => {
-                let diff = semver.diff(versionToRelease, version);
-                if (
-                    !diff ||
-                    (
-                        semver.lte(versionToRelease, version) &&
-                        diff === conflictingSemverDiff &&
-                        prereleaseName &&
-                        prereleaseName === (semver.prerelease(version) || [])[0]
-                    )
-                ) {
-                    return true;
-                }
-                return false;
-            });
-            if (conflictingVersions.length) {
-                throw new Error(`${releaseType} version ${versionToRelease} couldn't be published! Conflicting versions: ${conflictingVersions.join(', ')}`);
-            }
-            var versionArgs = ['version', versionToRelease, '-m', '[ci-skip][ci skip] version incremented to %s'];
-            // if (!setTag) {
-            //     versionArgs.unshift('--no-git-tag-version');
-            // }
-            exec('npm', versionArgs);
-            // if (!setTag) {
-            //     exec('git', ['commit', '-am', `[ci-skip][ci skip] version incremented to ${versionToRelease}`]);
-            // }
-            exec('git', ['push']);
-            exec('git', ['push', 'origin', '--tags']);
-            obfuscator.obfuscate();
-            exec('npm', setTag ? ['publish'] : ['publish', '--tag', 'ci', '--tag', tokens[1]]);
-            return true;
-        })
-        .catch(function(e) {
-            console.error(e);
-            return process.exit(1);
-        });
-    }
-});
+/* eslint no-console:0, no-process-exit:0 */
+const exec = require('../lib/exec');
+const versionBump = require('../lib/versionBump');
+const obfuscator = require('../lib/obfuscator');
+versionBump()
+    .then(({tag}) => {
+        exec('git', ['push']);
+        exec('git', ['push', 'origin', '--tags']);
+        obfuscator.obfuscate();
+        return exec('npm', tag ? ['publish', '--tag', tag] : ['publish']);
+    })
+    .catch(function(e) {
+        console.error(e);
+        process.exit(1);
+    });

--- a/bin/ut-versionbump.js
+++ b/bin/ut-versionbump.js
@@ -1,0 +1,7 @@
+/* eslint no-console:0, no-process-exit:0 */
+const versionBump = require('../lib/versionBump');
+versionBump()
+    .catch((e) => {
+        console.error(e);
+        process.exit(1);
+    });

--- a/lib/versionBump.js
+++ b/lib/versionBump.js
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+/* eslint no-process-env:0 */
+const exec = require('./exec');
+const path = require('path');
+const conventionalRecommendedBump = require('conventional-recommended-bump');
+const semver = require('semver');
+const pkgVersions = require('pkg-versions');
+const buildableBranches = {
+    hotfix: 'patch',
+    major: 'premajor',
+    minor: 'preminor',
+    patch: 'prepatch'
+};
+const getRecommendedReleaseType = () => {
+    return new Promise((resolve, reject) => {
+        conventionalRecommendedBump({
+            preset: 'angular'
+        }, function(err, result) {
+            return err ? reject(err) : resolve(result.releaseType);
+        });
+    });
+};
+module.exports = () => {
+    return getRecommendedReleaseType()
+        .then((releaseType) => {
+            const packageJson = require(path.join(process.cwd(), 'package.json'));
+            let tokens = [];
+            // if (process.env.gitlabSourceBranch) {
+            // tokens = process.env.gitlabSourceBranch.split('/');
+            // } else
+            if (process.env.CIRCLE_BRANCH) {
+                tokens = process.env.CIRCLE_BRANCH.split('/');
+            } else if (process.env.GIT_BRANCH) {
+                tokens = process.env.GIT_BRANCH.split('/').slice(1); // remove origin
+            } else {
+                throw new Error('Branch name could not be detected!');
+            }
+            let currentVersion = packageJson.version;
+            let tag = tokens[1];
+            let versionToRelease;
+            if (tokens.length === 2 && buildableBranches[tokens[0]] && tokens[1]) {
+                releaseType = buildableBranches[tokens[0]];
+                if (releaseType.startsWith('pre')) {
+                    let prereleaseTokens = semver.prerelease(currentVersion);
+                    if (prereleaseTokens) {
+                        if (prereleaseTokens[0] !== tokens[1]) {
+                            throw new Error(`Release version mismatch: Version ${prereleaseTokens[0]} can't be released from version ${tokens[1]}`);
+                        }
+                        releaseType = 'prerelease';
+                    } else {
+                        if (!semver.prerelease(currentVersion + '-' + tokens[1])) {
+                            throw new Error(`incorrect branch name: ${tokens.join('/')}! ${tokens[1]} MUST comprise only [0-9A-Za-z-]`);
+                        }
+                        versionToRelease = semver.inc(currentVersion, releaseType, tokens[1]);
+                    }
+                }
+            } else if (tokens.length > 1 || (tokens.length === 1 && tokens[0] !== 'master')) {
+                throw new Error(`incorrect branch name: ${tokens.join('/')}! Allowed branch names: master, hotfix/*, major/*, minor/*, patch/*`);
+            }
+            if (!versionToRelease) {
+                if (tokens[0] === 'master') {
+                    tag = null;
+                }
+                versionToRelease = semver.inc(currentVersion, releaseType);
+            }
+            return pkgVersions(packageJson.name)
+                .catch(function() {
+                    // return empty array in case a list of current versions could not be obtained.
+                    // This is needed when publishing for the first time.
+                    return [];
+                })
+                .then(function(versions) {
+                    var conflictingSemverDiff = releaseType;
+                    var prereleaseName = '';
+                    if (releaseType.startsWith('pre')) {
+                        conflictingSemverDiff = 'prerelease';
+                        prereleaseName = semver.prerelease(versionToRelease)[0];
+                    }
+                    var conflictingVersions = Array.from(versions).filter((version) => {
+                        let diff = semver.diff(versionToRelease, version);
+                        if (
+                            !diff ||
+                            (
+                                semver.lte(versionToRelease, version) &&
+                                diff === conflictingSemverDiff &&
+                                prereleaseName &&
+                                prereleaseName === (semver.prerelease(version) || [])[0]
+                            )
+                        ) {
+                            return true;
+                        }
+                        return false;
+                    });
+                    if (conflictingVersions.length) {
+                        throw new Error(`${releaseType} version ${versionToRelease} couldn't be published! Conflicting versions: ${conflictingVersions.join(', ')}`);
+                    }
+                    let versionArgs = ['version', versionToRelease, '-m', '[ci-skip][ci skip] version incremented to %s'];
+                    // if (!tags.length) {
+                    //     versionArgs.unshift('--no-git-tag-version');
+                    // }
+                    exec('npm', versionArgs);
+                    // if (!tags.length) {
+                    //     exec('git', ['commit', '-am', `[ci-skip][ci skip] version incremented to ${version}`]);
+                    // }
+                    return {
+                        version: versionToRelease,
+                        tag
+                    };
+                });
+        });
+};


### PR DESCRIPTION
Npm versioning logic has been moved to a separate file so that it can be used as a standalone command (ut-versionbump). It is internally called by ut-release so the old functionality should work the way it used to.
The reason for this request is that we would want to add sonar reporting generation between the version bumping and publishing. I.e.
1)  first bump the npm version.
2) then generate the Sonar report (for he correct version now).
3)  and just after that push to git and publish to npm.

