### PR TITLE
fix: whitelist koa middleware dependencies

### DIFF
--- a/lib/dependencies.json
+++ b/lib/dependencies.json
@@ -54,6 +54,8 @@
         "koa": "2.7.0",
         "koa-bodyparser": "4.2.1",
         "koa-compose": "4.1.0",
+        "koa-conditional-get": "2.0.0",
+        "koa-etag": "3.0.0",
         "koa-jwt": "3.5.1",
         "koa-router": "7.4.0",
         "koa-send": "5.0.0",


### PR DESCRIPTION
whitelist koa-conditional-get and koa-etag.
This is needed for this pull request: https://github.com/softwaregroup-bg/ut-port-swagger/pull/10/files