### PR TITLE
fix: whitelist jsoneditor@6.1.0

### DIFF
--- a/lib/dependencies.json
+++ b/lib/dependencies.json
@@ -49,6 +49,7 @@
         "jimp": "0.2.27",
         "joi": "13.7.0",
         "json-stringify-deterministic": "1.0.1",
+        "jsoneditor": "6.1.0",
         "jsonwebtoken": "8.5.0",
         "jwks-rsa": "1.4.0",
         "koa": "2.7.0",


### PR DESCRIPTION
Needed for: https://github.com/softwaregroup-bg/ut-run/pull/66