### PR TITLE
feat: dependencies; html-pdf - add version 2.2.0

### DIFF
--- a/lib/dependencies.json
+++ b/lib/dependencies.json
@@ -58,7 +58,7 @@
         "hapi-auth-jwt2": "8.1.0",
         "hapi-swagger": "9.1.2",
         "hapi": "17.6.0",
-        "html-pdf": "1.5.0",
+        "html-pdf": ["1.5.0", "2.2.0"],
         "http-proxy": "1.17.0",
         "ibmmq": "0.9.10",
         "iconv-lite": "0.4.19",


### PR DESCRIPTION
feat: dependencies; html-pdf - add version 2.2.0 to the whitelist.

Version 2.2.0 currently is used in the Generali project. Version 2.2.0 is needed, because version 1.5.0 is not working correctly when applying footers in the PDF. If the version is not increased in ut-tools, we will be unable to create successful Jenkins builds